### PR TITLE
fix: board sorting 

### DIFF
--- a/scripts/update_social_events_roles.mjs
+++ b/scripts/update_social_events_roles.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Update Social Events board roles on Members.teams:
+ *   - Yagnasri → "Social Events Director"
+ *   - Hannah   → "Social Events"
+ *   - Shourya  → "Social Events"
+ *
+ * Dry-run by default (logs intended changes only). Pass --apply to write.
+ *
+ * Env (loaded from repo-root .env / .env.local):
+ *   VITE_SUPABASE_URL or SUPABASE_URL
+ *   For --apply: SUPABASE_SERVICE_ROLE_KEY or VITE_SUPABASE_SECRET_API_KEY (RLS bypass)
+ *   For dry-run: VITE_SUPABASE_ANON_KEY is enough if Members select is allowed
+ *
+ * Usage:
+ *   node scripts/update_social_events_roles.mjs
+ *   node scripts/update_social_events_roles.mjs --apply
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TEAM_KEY = "SOCIAL_EVENTS";
+const APPLY = process.argv.includes("--apply");
+
+/** @type {{ match: RegExp, role: string }[]} */
+const UPDATES = [
+  { match: /^yagnasri\b/i, role: "Social Events Director" },
+  { match: /^hannah\b/i, role: "Social Events" },
+  { match: /^shourya\b/i, role: "Social Events" },
+];
+
+function loadEnvFiles() {
+  for (const name of [".env.local", ".env"]) {
+    const path = resolve(REPO_ROOT, name);
+    if (!existsSync(path)) continue;
+    const text = readFileSync(path, "utf8");
+    for (const raw of text.split(/\r?\n/)) {
+      let line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      if (line.toLowerCase().startsWith("export ")) line = line.slice(7).trim();
+      const eq = line.indexOf("=");
+      if (eq < 0) continue;
+      const key = line.slice(0, eq).trim();
+      let val = line.slice(eq + 1).trim();
+      if (
+        (val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))
+      ) {
+        val = val.slice(1, -1);
+      }
+      if (!key) continue;
+      if (process.env[key] && String(process.env[key]).trim()) continue;
+      process.env[key] = val;
+    }
+  }
+}
+
+function labelToTeamKey(label) {
+  return String(label).trim().replace(/\s+/g, "_").toUpperCase();
+}
+
+/** Normalize teams object keys; prefer SOCIAL_EVENTS storage key. */
+function normalizeTeams(raw) {
+  if (raw == null) return {};
+  let obj = raw;
+  if (typeof raw === "string") {
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof obj !== "object" || Array.isArray(obj)) return {};
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === "string" && v.trim()) out[k] = v.trim();
+  }
+  return out;
+}
+
+function hasSocialEvents(teams) {
+  return Object.keys(teams).some(k => labelToTeamKey(k) === TEAM_KEY);
+}
+
+function socialEventsRole(teams) {
+  if (typeof teams[TEAM_KEY] === "string") return teams[TEAM_KEY];
+  for (const [k, v] of Object.entries(teams)) {
+    if (labelToTeamKey(k) === TEAM_KEY) return v;
+  }
+  return undefined;
+}
+
+/** Build next teams map: drop legacy Social Events keys, set SOCIAL_EVENTS role. */
+function withSocialRole(teams, role) {
+  /** @type {Record<string, string>} */
+  const next = {};
+  for (const [k, v] of Object.entries(teams)) {
+    if (labelToTeamKey(k) === TEAM_KEY) continue;
+    next[k] = v;
+  }
+  next[TEAM_KEY] = role;
+  return next;
+}
+
+function matchUpdate(fullName) {
+  const name = String(fullName || "").trim();
+  return UPDATES.find(u => u.match.test(name)) ?? null;
+}
+
+async function main() {
+  loadEnvFiles();
+
+  const url = (process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "").trim();
+  const serviceKey = (
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.VITE_SUPABASE_SECRET_API_KEY ||
+    ""
+  ).trim();
+  const anonKey = (process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "").trim();
+
+  const key = APPLY ? serviceKey || anonKey : anonKey || serviceKey;
+  if (!url || !key) {
+    console.error("Missing Supabase URL or API key in env.");
+    process.exit(1);
+  }
+
+  if (APPLY && !serviceKey) {
+    console.warn(
+      "WARNING: --apply without service role key; update may fail under RLS. Set SUPABASE_SERVICE_ROLE_KEY."
+    );
+  }
+
+  const supabase = createClient(url, key);
+  console.log(APPLY ? "MODE: APPLY (will write)" : "MODE: DRY-RUN (no writes)");
+
+  const { data, error } = await supabase
+    .from("Members")
+    .select("id, full_name, email, teams, deleted")
+    .neq("teams", null)
+    .or("deleted.is.null,deleted.eq.false");
+
+  if (error) {
+    console.error("Fetch error:", error.message);
+    process.exit(1);
+  }
+
+  const social = (data ?? []).filter(row => hasSocialEvents(normalizeTeams(row.teams)));
+  console.log(`\nSocial Events members found: ${social.length}`);
+  for (const row of social) {
+    const teams = normalizeTeams(row.teams);
+    console.log(`  - ${row.full_name} | role=${socialEventsRole(teams) ?? "(none)"} | id=${row.id}`);
+  }
+
+  /** @type {{ id: string, name: string, email: string|null, from: string|undefined, to: string, nextTeams: Record<string,string> }[]} */
+  const planned = [];
+  const matchedNames = new Set();
+
+  for (const row of data ?? []) {
+    const teams = normalizeTeams(row.teams);
+    if (!hasSocialEvents(teams)) continue;
+    const upd = matchUpdate(row.full_name);
+    if (!upd) continue;
+    matchedNames.add(upd.match.source);
+    const from = socialEventsRole(teams);
+    if (from === upd.role && Object.prototype.hasOwnProperty.call(teams, TEAM_KEY)) {
+      console.log(`\nSKIP (already correct): ${row.full_name} → ${upd.role}`);
+      continue;
+    }
+    planned.push({
+      id: row.id,
+      name: row.full_name,
+      email: row.email,
+      from,
+      to: upd.role,
+      nextTeams: withSocialRole(teams, upd.role),
+    });
+  }
+
+  console.log("\n--- Planned updates ---");
+  if (planned.length === 0) {
+    console.log("(none)");
+  } else {
+    for (const p of planned) {
+      console.log(`${p.name} (${p.email ?? "no email"}) id=${p.id}`);
+      console.log(`  ${JSON.stringify(p.from)} → ${JSON.stringify(p.to)}`);
+      console.log(`  teams: ${JSON.stringify(p.nextTeams)}`);
+    }
+  }
+
+  for (const u of UPDATES) {
+    const found = (data ?? []).some(row => {
+      const teams = normalizeTeams(row.teams);
+      return hasSocialEvents(teams) && u.match.test(String(row.full_name || "").trim());
+    });
+    if (!found) {
+      console.warn(`\nWARNING: no Social Events member matched /${u.match.source}/`);
+    }
+  }
+
+  if (!APPLY) {
+    console.log("\nDry-run complete. Re-run with --apply to write.");
+    return;
+  }
+
+  let ok = 0;
+  let fail = 0;
+  for (const p of planned) {
+    const { data: updated, error: updErr } = await supabase
+      .from("Members")
+      .update({ teams: p.nextTeams })
+      .eq("id", p.id)
+      .select("id, teams");
+    if (updErr) {
+      fail += 1;
+      console.error(`FAILED ${p.name}: ${updErr.message}`);
+    } else if (!updated || updated.length === 0) {
+      fail += 1;
+      console.error(
+        `FAILED ${p.name}: update returned 0 rows (likely RLS blocked write). Set SUPABASE_SERVICE_ROLE_KEY.`
+      );
+    } else {
+      ok += 1;
+      console.log(`UPDATED ${p.name}: ${JSON.stringify(updated[0].teams)}`);
+    }
+  }
+  console.log(`\nDone. updated=${ok} failed=${fail}`);
+  if (fail > 0) process.exitCode = 1;
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/Shared/Components/HoverCard.tsx
+++ b/src/Shared/Components/HoverCard.tsx
@@ -10,6 +10,11 @@ interface HoverCardProps {
   size: string;
   image?: string;
   imgClassName?: string;
+  // 2026-08-05 archived: imageFit?: "cover" | "contain";
+  /** >1 zooms into the photo (object-cover). Only for per-card framing tweaks. */
+  imageScale?: number;
+  /** CSS object-position for per-card framing (e.g. "center 20%"). */
+  imagePosition?: string;
   placement?: number;
   link?: string;
   links?: {
@@ -28,6 +33,8 @@ const HoverCard = ({
   link,
   links,
   imgClassName,
+  imageScale = 1,
+  imagePosition,
   placement,
 }: HoverCardProps) => {
   const { imageStates } = useImagePreloader([image ? image : ""]);
@@ -82,6 +89,8 @@ const HoverCard = ({
         )}
 
         {image && imageLoaded && (
+          // 2026-08-05 archived:
+          // className={`size-full rounded-2xl ${imageFit === "contain" ? "object-contain" : "object-cover"}`}
           <img
             src={image}
             className="size-full object-cover rounded-2xl"
@@ -89,6 +98,9 @@ const HoverCard = ({
             decoding="async"
             style={{
               animation: "hc-fadeIn 0.35s ease-out forwards",
+              transform: imageScale !== 1 ? `scale(${imageScale})` : undefined,
+              transformOrigin: imageScale !== 1 ? "center top" : undefined,
+              objectPosition: imagePosition,
             }}
             onError={e => (e.currentTarget.style.display = "none")}
           />

--- a/src/Sites/Main/Pages/Board/Board.tsx
+++ b/src/Sites/Main/Pages/Board/Board.tsx
@@ -153,6 +153,12 @@ const Board = () => {
                           image={member.image}
                           size="200px"
                           links={formatMemberLinks(member)}
+                          // Nudge crop up for Daniel: more hair, less shirt; same zoom.
+                          imagePosition={
+                            member.name.trim().toLowerCase() === "daniel mathews"
+                              ? "center 22%"
+                              : undefined
+                          }
                         />
                       </motion.div>
                     </Suspense>

--- a/src/Sites/Main/Pages/Board/boardTeamConfig.ts
+++ b/src/Sites/Main/Pages/Board/boardTeamConfig.ts
@@ -34,7 +34,16 @@ export function roleForMemberOnTab(
   member: { teamRoles: Record<string, string> },
   tabKey: string
 ): string | undefined {
-  return member.teamRoles[tabKey];
+  // 2026-08-05 archived: return member.teamRoles[tabKey];
+  // Resolve by normalized key so legacy labels ("Social Events") and
+  // storage keys ("SOCIAL_EVENTS") both work for display + director sort.
+  if (Object.prototype.hasOwnProperty.call(member.teamRoles, tabKey)) {
+    return member.teamRoles[tabKey];
+  }
+  for (const [k, v] of Object.entries(member.teamRoles)) {
+    if (labelToTeamKey(k) === tabKey) return v;
+  }
+  return undefined;
 }
 
 /** Ordered tab keys: committees from `teams.json` key order first, then any extra keys in member data. */

--- a/src/Sites/Main/Pages/Board/useBoardMembers.ts
+++ b/src/Sites/Main/Pages/Board/useBoardMembers.ts
@@ -5,6 +5,7 @@ import { supabase } from "src/Utils/supabase";
 import { normalizeExternalHref } from "src/Utils/functions";
 import { normalizeTeamsField } from "src/Sites/Members/Utils/functions";
 import type { BoardMember } from "src/Utils/types.ts";
+import { roleForMemberOnTab } from "./boardTeamConfig";
 
 type MemberRow = {
   full_name: string;
@@ -20,19 +21,32 @@ type MemberRow = {
 
 /** Lower rank = earlier. `Vice President` before `President` so substrings don’t collide. */
 function boardRoleTitleImportanceRank(role: string | undefined | null): number {
-  if (!role?.trim()) return 3;
+  // 2026-08-05 archived:
+  // if (!role?.trim()) return 3;
+  // const lower = role.trim().toLowerCase();
+  // if (lower.includes("vice president")) return 1;
+  // if (lower.includes("president")) return 0;
+  // if (lower.includes("director")) return 2;
+  // return 3;
+  if (!role?.trim()) return 4;
   const lower = role.trim().toLowerCase();
   if (lower.includes("vice president")) return 1;
   if (lower.includes("president")) return 0;
   if (lower.includes("director")) return 2;
-  return 3;
+  if (lower.includes("mentor")) return 3;
+  return 4;
 }
 
 function compareBoardMembersForTeam(a: BoardMember, b: BoardMember, teamKey: string): number {
-  const ra = boardRoleTitleImportanceRank(a.teamRoles[teamKey]);
-  const rb = boardRoleTitleImportanceRank(b.teamRoles[teamKey]);
+  // 2026-08-05 archived:
+  // const ra = boardRoleTitleImportanceRank(a.teamRoles[teamKey]);
+  // const rb = boardRoleTitleImportanceRank(b.teamRoles[teamKey]);
+  // if (ra !== rb) return ra - rb;
+  // return b.teamRoles[teamKey]?.localeCompare(a.teamRoles[teamKey]) ?? 0;
+  const ra = boardRoleTitleImportanceRank(roleForMemberOnTab(a, teamKey));
+  const rb = boardRoleTitleImportanceRank(roleForMemberOnTab(b, teamKey));
   if (ra !== rb) return ra - rb;
-  return b.teamRoles[teamKey]?.localeCompare(a.teamRoles[teamKey]) ?? 0;
+  return a.name.localeCompare(b.name);
 }
 
 function rowToBoardMember(row: MemberRow): BoardMember | null {


### PR DESCRIPTION
## Summary
- Sort board members so Directors (then Mentors) appear first on each team tab, with robust team-key role lookup
- Add dry-run/apply script `scripts/update_social_events_roles.mjs` for Social Events role updates in Supabase